### PR TITLE
Allow QR-code(Hybrid) flow for webauthn.get

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,16 +52,16 @@ android {
 
 dependencies {
 
-    implementation("androidx.core:core-ktx:1.10.1")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
-    implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
+    implementation("androidx.activity:activity-compose:1.8.2")
     implementation(platform("androidx.compose:compose-bom:2023.08.00"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.android.material:material:1.9.0")
+    implementation("com.google.android.material:material:1.11.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation(platform("androidx.compose:compose-bom:2023.03.00"))
     testImplementation("junit:junit:4.13.2")
@@ -72,7 +72,7 @@ dependencies {
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.03.00"))
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
-    implementation ("androidx.credentials:credentials:1.2.0-beta03")
+    implementation ("androidx.credentials:credentials:1.2.0")
 
     implementation ("androidx.biometric:biometric-ktx:1.2.0-alpha05")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")

--- a/app/src/main/java/com/example/mycredman/CredmanUtils.kt
+++ b/app/src/main/java/com/example/mycredman/CredmanUtils.kt
@@ -9,6 +9,8 @@ object CredmanUtils {
 
     fun appInfoToOrigin(info: androidx.credentials.provider.CallingAppInfo): String {
 
+//        Log.d("CredmanUtils","!!!+++ PackageName:"+info.packageName );
+
         // https://www.gstatic.com/gpm-passkeys-privileged-apps/apps.json .)
         val privilegedAllowlist = """
             {
@@ -101,17 +103,18 @@ object CredmanUtils {
         val cert = info.signingInfo.apkContentsSigners[0].toByteArray()
         val md = MessageDigest.getInstance("SHA-256")
         val certHash = md.digest(cert)
-        Log.d("MyCredMan","!!!+++ apkhash +++!!!: ${b64Encode(certHash)}"  )
+        Log.d("CredmanUtils","!!!+++ apkhash +++!!!: ${b64Encode(certHash)}"  )
 
         // This is the format for origin
         var origin: String
         try{
             origin = info.getOrigin(privilegedAllowlist)!! // go to the catch clause when null
         }catch(e:Exception ){
-            Log.e("MyCredMan",e.toString()  )
+            Log.e("CredmanUtils",e.toString()  )
             origin="android:apk-key-hash:${b64Encode(certHash)}"
         }
-        Log.d("MyCredMan","!!!+++ origin +++!!!: ${origin}"  )
+        Log.d("CredmanUtils","!!!+++ origin +++!!!: ${origin}"  )
+
 
         return origin
     }
@@ -131,6 +134,7 @@ object CredmanUtils {
 
     fun validateRpId(info: androidx.credentials.provider.CallingAppInfo, rpid:String): String{
         var origin = appInfoToOrigin(info)
+        Log.d("CredmanUtils","!!!+++ rpid: $rpid");
         val rpIdForRexEx = rpid.replace(".","""\.""")
         if (Regex("""^https://([A-Za-z0-9\-.]*\.)?"""+rpIdForRexEx+"""($|/.*)""").matches(origin)){
             //take out  "https://" and trailing slash "/" to make origin a pure domain.

--- a/app/src/main/java/com/example/mycredman/CredmanUtils.kt
+++ b/app/src/main/java/com/example/mycredman/CredmanUtils.kt
@@ -132,7 +132,8 @@ object CredmanUtils {
     fun validateRpId(info: androidx.credentials.provider.CallingAppInfo, rpid:String): String{
         var origin = appInfoToOrigin(info)
         val rpIdForRexEx = rpid.replace(".","""\.""")
-        if (Regex("""^https://([A-Za-z0-9\-.]*\.)?"""+rpIdForRexEx+"""/.?""").matches(origin)){
+        if (Regex("""^https://([A-Za-z0-9\-.]*\.)?"""+rpIdForRexEx+"""($|/.*)""").matches(origin)){
+            //take out  "https://" and trailing slash "/" to make origin a pure domain.
             origin = rpid
         }
         return origin

--- a/app/src/main/java/com/example/mycredman/GetCredentialActivity.kt
+++ b/app/src/main/java/com/example/mycredman/GetCredentialActivity.kt
@@ -163,7 +163,7 @@ class GetCredentialActivity : AppCompatActivity() {
 
 @Serializable
 data class GetPublicKeyCredentialRequestJson(
-    val allowCredentials:Array<AllowCredential>,
+    val allowCredentials:Array<AllowCredential>? = null,
     val challenge:String,
     val rpId:String,
     val userVerification: String,

--- a/app/src/main/java/com/example/mycredman/GetCredentialActivity.kt
+++ b/app/src/main/java/com/example/mycredman/GetCredentialActivity.kt
@@ -38,14 +38,14 @@ class GetCredentialActivity : AppCompatActivity() {
         publicKeyRequests.forEach { credentialOption ->
 //            credentialOption.requestData.keySet().forEach { key ->
 //                val value = credentialOption.requestData.get(key)
-//                Log.d("MyCredMan", "key: $key, value: $value")
+//                Log.d("GetCredActivity", "key: $key, value: $value")
 //            }
-            Log.d("MyCredMan", "requsetJson:${credentialOption.requestJson}")
+            Log.d("GetCredActivity", "requsetJson: ${credentialOption.requestJson}")
         }
 
         val credIdEnc = requestInfo?.getString("credId")
         val requestJson = Json.decodeFromString<GetPublicKeyCredentialRequestJson>(publicKeyRequests[0].requestJson)
-        Log.d("MyCredMan", "rpid:${requestJson.rpId}")
+        Log.d("GetCredActivity", "rpid: ${requestJson.rpId}")
 
 // Get the saved passkey from your database based on the credential ID
 // from the publickeyRequest
@@ -120,6 +120,7 @@ class GetCredentialActivity : AppCompatActivity() {
                 val credential = FidoPublicKeyCredential(
                     rawId = credId, response = response
                     , authenticatorAttachment = "platform")
+                Log.d("GetCredActivity", "+++ credential.json(): "+ credential.json())
                 val result = Intent()
                 val passkeyCredential = PublicKeyCredential(credential.json())
                 PendingIntentHandler.setGetCredentialResponse(

--- a/app/src/main/java/com/example/mycredman/MainActivity.kt
+++ b/app/src/main/java/com/example/mycredman/MainActivity.kt
@@ -399,8 +399,21 @@ class MainActivity : AppCompatActivity() {
                     val credential = FidoPublicKeyCredential(
                         rawId = credId, response = response
                         , authenticatorAttachment = "platform")
+
+                    Log.d("MainActivity", "+++ credential.json(): "+ credential.json())
+//                    var credentialJson = credential.json()
+
+                    // add clientDataJSON to the response
+                    val clientDataJSONb64 = getClientDataJSONb64(origin, CredmanUtils.b64Encode( request.challenge))
+                    val delimiter = "response\":{"
+                    val credentialJson = credential.json().substringBeforeLast(delimiter)+ delimiter +
+                            "\"clientDataJSON\":\"$clientDataJSONb64\","+
+                            credential.json().substringAfterLast(delimiter)
+
+                    Log.d("MainActivity", "+++ credentialJson: "+ credentialJson)
+
                     val result = Intent()
-                    val passkeyCredential = PublicKeyCredential(credential.json())
+                    val passkeyCredential = PublicKeyCredential(credentialJson)
                     PendingIntentHandler.setGetCredentialResponse(
                         result, GetCredentialResponse(passkeyCredential)
                     )
@@ -420,6 +433,18 @@ class MainActivity : AppCompatActivity() {
             .setNegativeButtonText("Cancel") // this needs to be added when using BIOMETRIC
             .build()
         biometricPrompt.authenticate(promptInfo)
+    }
+
+
+    private fun getClientDataJSONb64(origin: String,challenge:String): String {
+
+        val origin = origin.replace(Regex("/$"), "")
+
+        val jsonString =
+            "{\"type\":\"webauthn.get\",\"challenge\":\"$challenge\",\"origin\":\"$origin\",\"crossOrigin\":false}"
+        val jsonByteArray = jsonString.toByteArray()
+        Log.d("MainActivity","+++ ClientDataJSON: $jsonString")
+        return CredmanUtils.b64Encode(jsonByteArray)
     }
 
 

--- a/app/src/main/java/com/example/mycredman/MainActivity.kt
+++ b/app/src/main/java/com/example/mycredman/MainActivity.kt
@@ -88,13 +88,13 @@ class MainActivity : AppCompatActivity() {
             val requestInfo = intent.getBundleExtra("CREDENTIAL_DATA")
 
             publicKeyRequests.forEach { credentialOption ->
-                Log.d("MyCredMan", "requsetJson:${credentialOption.requestJson}")
+                Log.d("MainActivity", "requsetJson:${credentialOption.requestJson}")
             }
 
             val credIdEnc = requestInfo?.getString("credId")
             val requestJson = Json.decodeFromString<GetPublicKeyCredentialRequestJson>(publicKeyRequests[0].requestJson)
-            Log.d("MyCredMan", "onCreate rpid:${requestJson.rpId}")
-            Log.d("MyCredMan", "${credIdEnc}")
+            Log.d("MainActivity", "onCreate rpid:${requestJson.rpId}")
+            Log.d("MainActivity", "${credIdEnc}")
 
 // Get the saved passkey from your database based on the credential ID
 // from the publickeyRequest
@@ -109,6 +109,7 @@ class MainActivity : AppCompatActivity() {
             val origin = CredmanUtils.appInfoToOrigin(getRequest.callingAppInfo)
             val packageName = getRequest.callingAppInfo.packageName
             val clientDataHash = publicKeyRequests[0].requestData.getByteArray("androidx.credentials.BUNDLE_KEY_CLIENT_DATA_HASH")
+            Log.d("MainActivity","+++ clientDataHash: "+CredmanUtils.b64Encode(clientDataHash!!))
 
             validatePasskey(
                 publicKeyRequests[0].requestJson,
@@ -170,12 +171,12 @@ class MainActivity : AppCompatActivity() {
                             shape = RoundedCornerShape(20.dp)
                         )
                         .clickable(onClick = {
-                            Log.d("MyCredMan", "onClick")
+                            Log.d("MainActivity", "onClick")
                             intent.putExtra("ServiceName", it.serviceName)
                             intent.putExtra("ServiceNameUrl", it.rpid)
                             intent.putExtra("ServiceNameId", it.displayName)
                             intent.putExtra("stringcredentialId", it.credentialId)
-                            Log.d("MyCredMan",it.credentialId.toString())
+                            Log.d("MainActivity",it.credentialId.toString())
                             startActivity(intent)
                         })
                         .padding(16.dp)
@@ -209,7 +210,7 @@ class MainActivity : AppCompatActivity() {
         clientDataHash: ByteArray?,
         accountId: String?
     ) {
-        Log.d("MyCredMan", "===requestJson===: "+requestJson)
+        Log.d("MainActivity", "===requestJson===: "+requestJson)
 
         val request = PublicKeyCredentialCreationOptions(requestJson)
 
@@ -252,7 +253,7 @@ class MainActivity : AppCompatActivity() {
 
                 // check if rpid is a subdomain of origin
                 val rpid = CredmanUtils.validateRpId(callingAppInfo!!,request.rp.id)
-                Log.d("MyCredMan", "===rpid === :" + rpid)
+                Log.d("MainActivity", "===rpid === :" + rpid)
 
                 // Save passkey in your database as per your own implementation
 
@@ -317,13 +318,13 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun populateEasyAccessorFields(json: String, rpid:String , keyPair: KeyPair, credentialId: ByteArray):String{
-        Log.d("MyCredMan","=== populateEasyAccessorFields BEFORE === "+ json)
+        Log.d("MainActivity","=== populateEasyAccessorFields BEFORE === "+ json)
         val response = Json.decodeFromString<CreatePublicKeyCredentialResponseJson>(json)
         response.response.publicKeyAlgorithm = -7 // ES256
         response.response.publicKey = CredmanUtils.b64Encode(keyPair.public.encoded)
         response.response.authenticatorData = getAuthData(rpid, credentialId, keyPair)
 
-        Log.d("MyCredMan","=== populateEasyAccessorFields AFTER === "+ Json.encodeToString(response))
+        Log.d("MainActivity","=== populateEasyAccessorFields AFTER === "+ Json.encodeToString(response))
         return Json.encodeToString(response)
 
     }
@@ -389,7 +390,7 @@ class MainActivity : AppCompatActivity() {
                         clientDataHash = clientDataHash
                     )
 
-                    Log.d("MyCredMan", "response.dataToSign(): ${CredmanUtils.b64Encode(response.dataToSign())}")
+                    Log.d("MainActivity", "response.dataToSign(): ${CredmanUtils.b64Encode(response.dataToSign())}")
 
                     val sig = Signature.getInstance("SHA256withECDSA")
                     sig.initSign(privateKey)

--- a/app/src/main/java/com/example/mycredman/MyCredentialProviderService.kt
+++ b/app/src/main/java/com/example/mycredman/MyCredentialProviderService.kt
@@ -194,11 +194,12 @@ class MyCredentialProviderService: androidx.credentials.provider.CredentialProvi
 
         val rpid = CredmanUtils.validateRpId(callingAppInfo,request.rpId)
         val creds = MyCredentialDataManager.load(this, rpid)
-        Log.d("MyCredMan", "requestJson:" + option.requestJson)
-        Log.d("MyCredMan", "rpid:" + rpid)
+        Log.d("ProviderService", "requestJson:" + option.requestJson)
+        Log.d("ProviderService", "rpid: $rpid")
 
 
         for (passkey in creds){
+            Log.d("ProviderService", "Found Passkey: " +passkey.displayName)
             val data = Bundle()
             data.putString("credId", CredmanUtils.b64Encode(passkey.credentialId))
             passkeyEntries.add(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.0" apply false
+    id("com.android.application") version "8.2.0" apply false
     id("org.jetbrains.kotlin.android") version "1.8.10" apply false
     kotlin("jvm") version "1.9.0"
     kotlin("plugin.serialization") version "1.9.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Aug 21 19:44:31 JST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixes a part of https://github.com/ko-koiwai/MyCredentialManager/issues/2

With QR-code (hybrid) flow, the origin within a request doesn't include trailing slash (requests from browsers were https://webauthn.io/ while from Google Lens were https://webauthn.io )

Thus the reqex to compare and exclude rpid (without https://) from origin (with https://) didn't work.